### PR TITLE
fix compile: add ivy-process-extension-spi

### DIFF
--- a/metaproc-connector/pom.xml
+++ b/metaproc-connector/pom.xml
@@ -16,6 +16,10 @@
       <groupId>com.axonivy.ivy.api</groupId>
       <artifactId>ivy-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.axonivy.ivy.spi</groupId>
+      <artifactId>ivy-process-extension-spi</artifactId>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>


### PR DESCRIPTION
this change is also not compatible with 13.1.1, but CI is red anyway.

```
Error:  Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.14.1:compile (default-compile) on project metaproc-connector: Compilation failure: Compilation failure: 
Error:  Unknown source: The type ch.ivyteam.ivy.process.extension.ProgramConfig cannot be resolved. It is indirectly referenced from required type ch.ivyteam.ivy.process.intermediateevent.AbstractProcessIntermediateEventBean
Error:  Unknown source: java.lang.NullPointerException: Cannot read the array length because "value" is null
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
```